### PR TITLE
Update fixed-resizable-hybrid

### DIFF
--- a/plugins/fixed-resizable-hybrid
+++ b/plugins/fixed-resizable-hybrid
@@ -1,2 +1,2 @@
 repository=https://github.com/Lapask/fixed-resizable-hybrid.git
-commit=1dfd3d622e7c2026aef1cd1056627613d51034bb
+commit=aa53977252a8fc73ca041e7c0439e0316d6b969d


### PR DESCRIPTION
- Changed gap widget to gap overlay to prevent overlays from rending through. Updated to be static final to prevent reloading resource images every frame.

- Added Wide Chat Mode, which stretches the chat and dialogue across the bottom of the viewport like in fixed mode. When open, it resizes the viewport to recenter the player on what is visible. Configurable in settings.